### PR TITLE
Move away from using in-memory structure for known path lookups to da…

### DIFF
--- a/analytics/analytics/hooks.py
+++ b/analytics/analytics/hooks.py
@@ -1,6 +1,3 @@
-import json
-import logging
-
 import bottle
 
 from .commands import stats_from_file
@@ -10,15 +7,6 @@ bottle.BaseRequest.MEMFILE_MAX = 1024 * 1024 * 10  # 10MB
 
 
 def initialize(supervisor):
-    try:
-        with open(supervisor.config['updates.file'], 'r') as updates_file:
-            data = json.load(updates_file)
-    except Exception:
-        logging.error('Known paths file could not be read.')
-        supervisor.app.known_paths = dict()
-    else:
-        supervisor.app.known_paths = data
-
     supervisor.exts.commands.register(
         'import',
         stats_from_file,

--- a/analytics/analytics/migrations/reports/00_04_add_lookup_table.py
+++ b/analytics/analytics/migrations/reports/00_04_add_lookup_table.py
@@ -1,0 +1,11 @@
+SQL = """
+create table lookup
+(
+    md5 varchar unique not null,
+    path varchar not null
+);
+"""
+
+
+def up(db, conf):
+    db.executescript(SQL)


### PR DESCRIPTION
This PR drops the reading of known paths from the JSON file on each app startup and storing the data in an in-memory dict to store the data in the database instead, and perform lookups from there as well. Updates the `/updates/` endpoint accordingly.
